### PR TITLE
Fix: add missing fields to data models

### DIFF
--- a/src/mdocfile/data_models.py
+++ b/src/mdocfile/data_models.py
@@ -18,6 +18,7 @@ class MdocGlobalData(BaseModel):
     ImageFile: Optional[Path] = None
     PixelSpacing: Optional[float] = None
     Voltage: Optional[float] = None
+    Version: Optional[str] = None
 
     @field_validator('ImageSize', mode="before")
     @classmethod
@@ -96,6 +97,7 @@ class MdocSectionData(BaseModel):
     UsingCDS: Optional[bool] = None
     CameraIndex: Optional[int] = None
     DividedBy2: Optional[bool] = None
+    RotationAndFlip: Optional[int] = None
     LowDoseConSet: Optional[int] = None
     MinMaxMean: Optional[Tuple[float, float, float]] = None
     PriorRecordDose: Optional[float] = None


### PR DESCRIPTION
Hi, I noticed that when I was trying to write some data to a mdocfile, two fields would be missing from my data. The `RotationAndFlip` field matches the standard from https://bio3d.colorado.edu/SerialEM/betaHlp/html/about_formats.htm, but the `Version` global data field was something I thought would be nice to have, though happy to remove it. Thanks! 