### PR TITLE
Fix reading mdoc files from older SerialEM

### DIFF
--- a/src/mdocfile/data_models.py
+++ b/src/mdocfile/data_models.py
@@ -101,8 +101,8 @@ class MdocSectionData(BaseModel):
     LowDoseConSet: Optional[int] = None
     MinMaxMean: Optional[Tuple[float, float, float]] = None
     PriorRecordDose: Optional[float] = None
-    XedgeDxy: Optional[Tuple[float, float]] = None
-    YedgeDxy: Optional[Tuple[float, float]] = None
+    XedgeDxy: Optional[Union[Tuple[float, float], Tuple[float, float, float]]] = None
+    YedgeDxy: Optional[Union[Tuple[float, float], Tuple[float, float, float]]] = None
     XedgeDxyVS: Optional[Union[Tuple[float, float], Tuple[float, float, float]]] = None
     YedgeDxyVS: Optional[Union[Tuple[float, float], Tuple[float, float, float]]] = None
     StageOffsets: Optional[Tuple[float, float]] = None


### PR DESCRIPTION
I was trying to read mdoc file for a grid map, and I found that the current implementation does not consider three-float entry of `XedgeDxy` and `YedgeDxy`, probably because this file was written by SerialEM Version 4.1.10.

This PR fixes the type annotation of the model class so that it can also read this type of mdoc file.